### PR TITLE
Allow easy setting of character limit

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -45,7 +45,6 @@ SMTP_FROM_ADDRESS=notifications@example.com
 #SMTP_OPENSSL_VERIFY_MODE=peer
 #SMTP_ENABLE_STARTTLS_AUTO=true
 
-
 # Optional user upload path and URL (images, avatars). Default is :rails_root/public/system. If you set this variable, you are responsible for making your HTTP server (eg. nginx) serve these files.
 # PAPERCLIP_ROOT_PATH=/var/lib/mastodon/public-system
 # PAPERCLIP_ROOT_URL=/system
@@ -86,3 +85,6 @@ SMTP_FROM_ADDRESS=notifications@example.com
 # Separate these by pipes if you want to load more than one of each
 SKIN=rooty
 FRONTEND=tooty
+
+# Character limit (defaults to 500 if not specified)
+MAX_CHARS=500

--- a/app/assets/frontends/tooty/scripting/features/compose/components/compose_form.jsx
+++ b/app/assets/frontends/tooty/scripting/features/compose/components/compose_form.jsx
@@ -37,6 +37,7 @@ const ComposeForm = React.createClass({
     is_submitting: React.PropTypes.bool,
     is_uploading: React.PropTypes.bool,
     me: React.PropTypes.number,
+    max_chars: React.PropTypes.number.isRequired,
     needsPrivacyWarning: React.PropTypes.bool,
     mentionedDomains: React.PropTypes.array.isRequired,
     onChange: React.PropTypes.func.isRequired,
@@ -197,7 +198,7 @@ const ComposeForm = React.createClass({
           </div>
 
           <div style={{ display: 'flex' }}>
-            <div style={{ paddingTop: '10px', marginRight: '16px', lineHeight: '36px' }}><CharacterCounter max={500} text={[this.props.spoiler_text, this.props.text].join('')} /></div>
+            <div style={{ paddingTop: '10px', marginRight: '16px', lineHeight: '36px' }}><CharacterCounter max={this.props.max_chars} text={[this.props.spoiler_text, this.props.text].join('')} /></div>
             <div style={{ paddingTop: '10px' }}><Button text={publishText} onClick={this.handleSubmit} disabled={disabled} /></div>
           </div>
         </div>

--- a/app/assets/frontends/tooty/scripting/features/compose/containers/compose_form_container.jsx
+++ b/app/assets/frontends/tooty/scripting/features/compose/containers/compose_form_container.jsx
@@ -34,6 +34,7 @@ const mapStateToProps = (state, props) => {
     is_submitting: state.getIn(['compose', 'is_submitting']),
     is_uploading: state.getIn(['compose', 'is_uploading']),
     me: state.getIn(['compose', 'me']),
+    max_chars: state.getIn(['compose', 'max_chars']),
     needsPrivacyWarning: (state.getIn(['compose', 'privacy']) === 'private' || state.getIn(['compose', 'privacy']) === 'direct') && mentionedUsernames !== null,
     mentionedDomains: mentionedUsernamesWithDomains
   };

--- a/app/validators/status_length_validator.rb
+++ b/app/validators/status_length_validator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class StatusLengthValidator < ActiveModel::Validator
-  MAX_CHARS = 500
+  MAX_CHARS = Rails.application.config.x.max_chars
 
   def validate(status)
     return unless status.local? && !status.reblog?

--- a/app/views/home/initial_state.json.rabl
+++ b/app/views/home/initial_state.json.rabl
@@ -14,6 +14,7 @@ node(:compose) do
   {
     me: current_account.id,
     default_privacy: current_account.user.setting_default_privacy,
+    max_chars: Rails.application.config.x.max_chars
   }
 end
 

--- a/config/initializers/max_chars.rb
+++ b/config/initializers/max_chars.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Rails.application.configure do
+  if ENV['MAX_CHARS'] and not ENV['MAX_CHARS'].empty?
+    config.x.max_chars = ENV['MAX_CHARS'].to_i
+  else
+    config.x.max_chars = 500
+  end
+end


### PR DESCRIPTION
Creates a `MAX_CHARS` environment variable that instance owners can set to change the maximum number of characters (defaults to `500`).