### PR TITLE
Fix CSS

### DIFF
--- a/app/assets/skins/rooty/styling/components.scss
+++ b/app/assets/skins/rooty/styling/components.scss
@@ -56,6 +56,7 @@
 @media screen and (min-width: 1025px) {
   .column-icon-clear {
     top: 10px;
+    padding: 5px;
   }
 }
 

--- a/app/assets/skins/rooty/styling/components.scss
+++ b/app/assets/skins/rooty/styling/components.scss
@@ -866,34 +866,12 @@ a.status__content__spoiler-link {
 @media screen and (min-width: 1025px) {
   .columns-area {
     padding: 0;
+    margin: 10px 5px;
   }
 
   .column, .drawer {
     flex: 0 0 auto;
-    padding: 10px;
-    padding-left: 5px;
-    padding-right: 5px;
-
-    &:first-child {
-      padding-left: 10px;
-    }
-
-    &:last-child {
-      padding-right: 10px;
-    }
-  }
-}
-
-@media screen and (min-width: 2560px) {
-  .columns-area {
-    justify-content: center;
-  }
-
-  .column, .drawer {
-    width: 350px;
-    border-radius: 4px;
-    height: 90vh;
-    margin-top: 5vh;
+    padding: 0 5px;
   }
 }
 


### PR DESCRIPTION
Someone thought it would be a good idea to squish the mastodon UI into a small rectangle on large screens for some reason (Example: [very LARGE IMAGE](http://puu.sh/vzx4l/0f41dac297.png)). This changes to using the standard layout for large (above 1080p) screens and cleans up a few lines or redundant css.